### PR TITLE
Add acceptance tests, DRY_RUN option, return for auth function if sourced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+.robot/
+.venv/
+**/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,16 @@ RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION
     && helm init --client-only \
     && helm plugin install https://github.com/hypnoglow/helm-s3.git \
     && helm plugin install https://github.com/nouney/helm-gcs.git \
-    && helm plugin install https://github.com/chartmuseum/helm-push.git   
+    && helm plugin install https://github.com/chartmuseum/helm-push.git
+
+# Run acceptance tests
+COPY Makefile Makefile
+COPY bin/ bin/
+COPY acceptance_tests/ acceptance_tests/
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && pip install virtualenv \
+    && make acceptance
 
 FROM codefresh/kube-helm:${HELM_VERSION}
 COPY --from=setup /root/.helm/ /root/.helm/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+ACCEPTANCE_PY_REQUIRES = robotframework==3.0.4
+
+HAS_VENV := $(shell command -v virtualenv)
+
+.PHONY: acceptance
+acceptance:
+ifndef HAS_VENV
+	$(error Must install virtualenv)
+endif
+ifeq (,$(wildcard .venv/))
+	virtualenv -p $$(which python2.7) .venv/
+	.venv/bin/python .venv/bin/pip install $(ACCEPTANCE_PY_REQUIRES)
+endif
+	mkdir -p .robot/
+	PATH=$(CURDIR)/bin:$(PATH) .venv/bin/robot --outputdir=.robot/ acceptance_tests/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 ACCEPTANCE_PY_REQUIRES = robotframework==3.0.4
 
-HAS_VENV := $(shell command -v virtualenv)
-
 .PHONY: acceptance
 acceptance:
-ifndef HAS_VENV
-	$(error Must install virtualenv)
-endif
 ifeq (,$(wildcard .venv/))
 	virtualenv -p $$(which python2.7) .venv/
 	.venv/bin/python .venv/bin/pip install $(ACCEPTANCE_PY_REQUIRES)

--- a/acceptance_tests/action-auth.robot
+++ b/acceptance_tests/action-auth.robot
@@ -7,6 +7,7 @@ Library           lib/CFStepHelm.py
 # 255 is a custom code we have for the "Source with env and check for var" command
 Sourcing will provide exported environment variables
     &{env}=   Create dictionary
+    Set to dictionary   ${env}  DRY_RUN   true
     Set to dictionary   ${env}  ACTION   auth
     Set to dictionary   ${env}  GOOGLE_APPLICATION_CREDENTIALS_JSON   {"x": "y"}
 
@@ -21,6 +22,7 @@ Sourcing will provide exported environment variables
 
 If not sourced it will exit 0
     &{env}=   Create dictionary
+    Set to dictionary   ${env}  DRY_RUN   true
     Set to dictionary   ${env}  ACTION   auth
 
     Run with env   ${env}

--- a/acceptance_tests/action-auth.robot
+++ b/acceptance_tests/action-auth.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation     Tests to verify functionality of ACTION=auth
+Library           Collections
+Library           lib/CFStepHelm.py
+
+*** Test Cases ***
+# 255 is a custom code we have for the "Source with env and check for var" command
+Sourcing will provide exported environment variables
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  ACTION   auth
+    Set to dictionary   ${env}  GOOGLE_APPLICATION_CREDENTIALS_JSON   {"x": "y"}
+
+    Source with env and check for var  ${env}   GOOGLE_APPLICATION_CREDENTIALS
+    Return code should be   255
+
+    Source with env and check for var  ${env}   HELM_REPO_ACCESS_TOKEN
+    Return code should be   255
+
+    Source with env and check for var  ${env}   HELM_REPO_AUTH_HEADER
+    Return code should be   255
+
+If not sourced it will exit 0
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  ACTION   auth
+
+    Run with env   ${env}
+    Return code should be   0

--- a/acceptance_tests/action-install.robot
+++ b/acceptance_tests/action-install.robot
@@ -1,0 +1,87 @@
+*** Settings ***
+Documentation     Tests to verify functionality of ACTION=install
+Library           Collections
+Library           lib/CFStepHelm.py
+
+*** Test Cases ***
+Install local chart no overrides
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+
+Install remote chart no overrides using CHART_REPO_URL
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CHART_REPO_URL   https://myhelmrepo.com
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --repo https://myhelmrepo.com
+
+Install chart with CHART_VERSION
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CHART_VERSION   1.1.1
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --version 1.1.1
+
+Install chart with NAMESPACE
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  NAMESPACE   staging
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --namespace=staging
+
+Install detects CUSTOMFILE_ and VALUESFILE_ environment vars and converts correctly
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CUSTOMFILE_FILE1    my/custom/file1.yaml
+    Set to dictionary   ${env}  CUSTOMFILE_FILE2    my/custom/file2.yaml
+    Set to dictionary   ${env}  VALUESFILE_FILE1    my/values/file1.yaml
+    Set to dictionary   ${env}  VALUESFILE_FILE2    my/values/file2.yaml
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --values my/custom/file1.yaml
+    Output contains   --values my/custom/file2.yaml
+    Output contains   --values my/values/file1.yaml
+    Output contains   --values my/values/file2.yaml
+
+Install detects CUSTOM_ and VALUE_ environment vars and converts correctly
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CUSTOM_myimage_pullPolicy   Always
+    Set to dictionary   ${env}  VALUE_myimage_customField   Other
+    Set to dictionary   ${env}  CUSTOM_env_open_STORAGE__AMAZON__BUCKET   my-s3-bucket
+    Set to dictionary   ${env}  VALUE_env_open_STORAGE__AMAZON__REGION   us-west-2
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --set myimage.pullPolicy=Always
+    Output contains   --set myimage.customField=Other
+    Output contains   --set env.open.STORAGE_AMAZON_BUCKET=my-s3-bucket
+    Output contains   --set env.open.STORAGE_AMAZON_REGION=us-west-2

--- a/acceptance_tests/action-install.robot
+++ b/acceptance_tests/action-install.robot
@@ -85,3 +85,15 @@ Install detects CUSTOM_ and VALUE_ environment vars and converts correctly
     Output contains   --set myimage.customField=Other
     Output contains   --set env.open.STORAGE_AMAZON_BUCKET=my-s3-bucket
     Output contains   --set env.open.STORAGE_AMAZON_REGION=us-west-2
+
+CMD_PS is passed to the end of install command
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CMD_PS   --my-fake-flag
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+    Output contains   --my-fake-flag

--- a/acceptance_tests/action-push.robot
+++ b/acceptance_tests/action-push.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Documentation     Tests to verify functionality of ACTION=push
+Library           Collections
+Library           lib/CFStepHelm.py
+
+*** Test Cases ***
+Able to push to ChartMuseum repo
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  ACTION   push
+    Set to dictionary   ${env}  CHART_REPO_URL  cm://my-cm-repo.com
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm push
+
+Able to push to S3 repo
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  ACTION   push
+    Set to dictionary   ${env}  CHART_REPO_URL  s3://my-s3-bucket
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm s3 push
+
+Able to push to GCS repo
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  ACTION   push
+    Set to dictionary   ${env}  CHART_REPO_URL  gs://my-gcs-bucket
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm gcs push
+
+CHART_REPO_URL is set automatically given CF_CTX_CF_HELM_DEFAULT_URL and normalized to contain a trailing slash
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CF_CTX_CF_HELM_DEFAULT_URL   cm://h.cfcr.io/myaccount/default
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   cm://h.cfcr.io/myaccount/default/

--- a/acceptance_tests/codefresh-contexts.robot
+++ b/acceptance_tests/codefresh-contexts.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Documentation     Tests to verify integration with attached Codefresh contexts
+Library           Collections
+Library           lib/CFStepHelm.py
+
+*** Test Cases ***
+CHART_REPO_URL is set automatically given CF_CTX_CF_HELM_DEFAULT_URL and normalized to contain a trailing slash
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CF_CTX_CF_HELM_DEFAULT_URL   cm://h.cfcr.io/myaccount/default
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   cm://h.cfcr.io/myaccount/default/
+
+Helm username and password added to an https CHART_REPO_URL given HELMREPO_USERNAME
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Set to dictionary   ${env}  CF_CTX_MYREPO_URL   https://myhelmrepo.com
+    Set to dictionary   ${env}  HELMREPO_USERNAME   user
+    Set to dictionary   ${env}  HELMREPO_PASSWORD   pass
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   https://user:pass@myhelmrepo.com

--- a/acceptance_tests/lib/CFStepHelm.py
+++ b/acceptance_tests/lib/CFStepHelm.py
@@ -1,0 +1,11 @@
+import common
+
+
+class CFStepHelm(common.CommandRunner):
+    def run_with_env(self, env={}):
+        self.run_command_with_env(['release_chart'], False, env)
+
+    def source_with_env_and_check_for_var(self, env={}, var=''):
+        self.run_command_with_env([
+            '/bin/sh', '-xc', 'unset $%s && source release_chart && ( env | grep -q %s ) && exit 255' % (var, var)
+        ], False, env)

--- a/acceptance_tests/lib/CFStepHelm.py
+++ b/acceptance_tests/lib/CFStepHelm.py
@@ -7,5 +7,5 @@ class CFStepHelm(common.CommandRunner):
 
     def source_with_env_and_check_for_var(self, env={}, var=''):
         self.run_command_with_env([
-            '/bin/sh', '-xc', 'unset $%s && source release_chart && ( env | grep -q %s ) && exit 255' % (var, var)
+            '/bin/sh', '-xc', 'unset $%s && . release_chart && ( env | grep -q %s ) && exit 255' % (var, var)
         ], False, env)

--- a/acceptance_tests/lib/common.py
+++ b/acceptance_tests/lib/common.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+
+
+class CommandRunner(object):
+    def __init__(self):
+        self.rc = 0
+        self.pid = 0
+        self.stdout = ''
+        self.rootdir = os.path.realpath(os.path.join(__file__, '../../../'))
+
+    def return_code_should_be(self, expected_rc):
+        if int(expected_rc) != self.rc:
+            raise AssertionError('Expected return code to be "%s" but was "%s".'
+                                 % (expected_rc, self.rc))
+
+    def return_code_should_not_be(self, expected_rc):
+        if int(expected_rc) == self.rc:
+            raise AssertionError('Expected return code not to be "%s".' % expected_rc)
+
+    def output_contains(self, s):
+        if s not in self.stdout:
+            raise AssertionError('Output does not contain "%s".' % s)
+
+    def output_does_not_contain(self, s):
+        if s in self.stdout:
+            raise AssertionError('Output contains "%s".' % s)
+
+    def run_command_with_env(self, command, detach=False, env={}):
+        execution_env = os.environ.copy()
+        for key, val in env.iteritems():
+            execution_env[str(key)] = str(val)
+        process = subprocess.Popen(command,
+                                   env=execution_env,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT)
+        if not detach:
+            stdout = process.communicate()[0].strip()
+            print(stdout)
+            self.rc = process.returncode
+            # Remove debug lines that start with "+ "
+            self.stdout = '\n'.join(filter(lambda x: not x.startswith('+ '), stdout.split('\n')))
+
+
+    def should_have_failed(self):
+        return self.return_code_should_not_be(0)
+
+    def should_have_succeeded(self):
+        return self.return_code_should_be(0)

--- a/acceptance_tests/required-env-vars.robot
+++ b/acceptance_tests/required-env-vars.robot
@@ -1,0 +1,75 @@
+*** Settings ***
+Documentation     Tests to verify required sets of env vars
+Library           Collections
+Library           lib/CFStepHelm.py
+
+*** Test Cases ***
+Crashes if missing CHART_REF or CHART_NAME
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have failed
+
+Will not crash if has one of CHART_REF or CHART_NAME
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have succeeded
+
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_NAME   mychartname
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have succeeded
+
+Will use CHART_REF over CHART_NAME if both are provided
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  CHART_NAME   mychartname
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   mychartref
+
+Crashes if missing RELEASE_NAME (ACTION=install)
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have failed
+
+Crashes if missing KUBE_CONTEXT (ACTION=install)
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have failed
+
+No env vars required if ACTION=auth
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  ACTION   auth
+    Run with env   ${env}
+    Should have succeeded
+
+Default ACTION is install
+    &{env}=   Create dictionary
+    Set to dictionary   ${env}  CHART_REF   mychartref
+    Set to dictionary   ${env}  RELEASE_NAME   my-release
+    Set to dictionary   ${env}  KUBE_CONTEXT   my-context
+    Set to dictionary   ${env}  DRY_RUN   true
+    Run with env   ${env}
+    Should have succeeded
+    Output contains   helm upgrade
+
+

--- a/bin/release_chart
+++ b/bin/release_chart
@@ -18,12 +18,16 @@ processRepoContexts() {
 			msg "Adding basic auth to REPO URL"
 			varValue=$(echo $varValue | sed -rn 's/(https?:\/\/)(.*)/\1'"${HELMREPO_USERNAME}"':'"${HELMREPO_PASSWORD}"'@\2/p')
 		fi
-		
+
 		export CHART_REPO_URL=$varValue/ #workaround a bug in Helm where url that doesn't end with / breaks --repo flags
 		msg "CHART_REPO_URL set to $CHART_REPO_URL"
-		
+
 		msg "adding repo : $CHART_REPO_URL"
-		helm repo add $tempRepoName $CHART_REPO_URL
+		if [ -z "$DRY_RUN" ]; then
+		    helm repo add $tempRepoName $CHART_REPO_URL
+		else
+		    echo helm repo add $tempRepoName $CHART_REPO_URL
+		fi
 	done
 }
 
@@ -56,9 +60,9 @@ fixGcsContext() {
 }
 
 fixCfContext() {
-  msg "Adding Codefresh token for managed repository"
-	export HELM_REPO_ACCESS_TOKEN=$CF_API_KEY
-	export HELM_REPO_AUTH_HEADER="x-access-token"
+    msg "Adding Codefresh token for managed repository"
+    export HELM_REPO_ACCESS_TOKEN=$CF_API_KEY
+    export HELM_REPO_AUTH_HEADER="x-access-token"
 }
 
 # get chart reference (required)
@@ -88,7 +92,11 @@ if [ "$ACTION" == 'install' ]; then
 		err "Please, set Kubernetes context. Use name from Codefresh Integrations page."
 	else
 		msg "Using ${KUBE_CONTEXT} context"
-		kubectl config use-context ${KUBE_CONTEXT}
+		if [ -z "$DRY_RUN" ]; then
+		    kubectl config use-context ${KUBE_CONTEXT}
+		else
+		    echo kubectl config use-context ${KUBE_CONTEXT}
+		fi
 	fi
 fi
 
@@ -114,19 +122,23 @@ fi
 
 # set chart version flag
 if [ ! -z "${CHART_VERSION}" ]; then
-  version="--version ${CHART_VERSION}"
+    version="--version ${CHART_VERSION}"
 fi
 
 if [ "$ACTION" == 'auth' ]; then
-  msg "Authentication context has been setup, exiting."
-	exit 0
+    msg "Authentication context has been setup, exiting."
+    exit 0
 fi
 
 if [ ! -z "${CHART_REPO_URL}" ]; then
-  	repoUrl="--repo ${CHART_REPO_URL}"
+    repoUrl="--repo ${CHART_REPO_URL}"
 else #if installing from local, "unpacked" chart, then restore dependencies first
-  msg "Building dependencies"
-  helm dependency build $chart
+    msg "Building dependencies"
+    if [ -z "$DRY_RUN" ]; then
+        helm dependency build $chart
+    else
+        echo helm dependency build $chart
+    fi
 fi
 
 if [ "$ACTION" == 'push' ]; then
@@ -136,20 +148,34 @@ if [ "$ACTION" == 'push' ]; then
 	case $CHART_REPO_URL in
 		cm*)
 			msg "Pushing to Chart Museum"
-	    		helm push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			if [ -z "$DRY_RUN" ]; then
+				helm push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			else
+				echo helm push $PACKAGE $tempRepoName
+			fi
 			;;
 		s3*)
 			msg "Pushing to S3 bucket"
-	    		helm s3 push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			if [ -z "$DRY_RUN" ]; then
+				helm s3 push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			else
+				echo helm s3 push $PACKAGE $tempRepoName
+			fi
 			;;
 		gs*)
 			msg "Pushing to GCS bucket"
-			helm gcs push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			if [ -z "$DRY_RUN" ]; then
+				helm gcs push $PACKAGE $tempRepoName && msg "Successfully pushed" || msg "Push failed"
+			else
+				echo helm gcs push $PACKAGE $tempRepoName
+			fi
 			;;
 	esac
 else
 	msg "Installing chart"
 	helmCmd="helm upgrade $release $chart --install $repoUrl $version $customFlags --force --reset-values $namespace $customVals $CMD_PS"
 	msg "$helmCmd"
-	eval "$helmCmd"
+	if [ -z "$DRY_RUN" ]; then
+	    eval "$helmCmd"
+	fi
 fi

--- a/bin/release_chart
+++ b/bin/release_chart
@@ -129,7 +129,7 @@ fi
 
 if [ "$ACTION" == 'auth' ]; then
     msg "Authentication context has been setup, exiting."
-    exit 0
+    [[ $_ != $0 ]] && return 0 || exit 0
 fi
 
 if [ ! -z "${CHART_REPO_URL}" ]; then

--- a/bin/release_chart
+++ b/bin/release_chart
@@ -65,19 +65,21 @@ fixCfContext() {
     export HELM_REPO_AUTH_HEADER="x-access-token"
 }
 
-# get chart reference (required)
-if [ -z "$CHART_REF" ]; then
-	if [ -z "$CHART_NAME" ]; then
-		err "Please, specify Helm Chart with CHART_REF environment variable this should be a reference to the chart as Helm CLI expects"
-	else
-		chart="${CHART_NAME}"
-	fi
-else
-	chart="${CHART_REF}"
-fi
-
 if [ -z "$ACTION" ]; then
 	ACTION='install'
+fi
+
+if [ "$ACTION" != 'auth' ]; then
+    # get chart reference (required)
+    if [ -z "$CHART_REF" ]; then
+        if [ -z "$CHART_NAME" ]; then
+            err "Please, specify Helm Chart with CHART_REF environment variable this should be a reference to the chart as Helm CLI expects"
+        else
+            chart="${CHART_NAME}"
+        fi
+    else
+        chart="${CHART_REF}"
+    fi
 fi
 
 if [ "$ACTION" == 'install' ]; then

--- a/bin/release_chart
+++ b/bin/release_chart
@@ -145,7 +145,12 @@ fi
 
 if [ "$ACTION" == 'push' ]; then
 	msg "Packaging the chart"
-	PACKAGE=$(helm package $chart $version --destination /dev/shm/ | cut -d " " -f 8)
+
+	if [ -z "$DRY_RUN" ]; then
+	    PACKAGE=$(helm package $chart $version --destination /dev/shm/ | cut -d " " -f 8)
+	else
+	    PACKAGE="dryrun-0.0.1.tgz"
+	fi
 
 	case $CHART_REPO_URL in
 		cm*)

--- a/bin/release_chart
+++ b/bin/release_chart
@@ -35,14 +35,14 @@ processRepoContexts() {
 processCustomVals() {
 	local resultedArgs=""
 
-	local vars=$(env | awk -F '=' '{print $1}' | grep -i -e "^customFile_" -e "^valuesFile_")
+	local vars="$(env | awk -F '=' '{print $1}' | grep -i -e "^customFile_" -e "^valuesFile_")"
 	for var in $vars
 	do
 		local varValue=$(eval "echo \$$var")
 		resultedArgs="$resultedArgs --values $varValue"
 	done
 
-	local vars=$(env | awk -F '=' '{print $1}' | grep -i -e "^custom_" -e "^value_")
+	local vars="$(env | awk -F '=' '{print $1}' | grep -i -e "^custom_" -e "^value_")"
 	for var in $vars
 	do
 		local varName=$(echo $var | sed 's/^custom_\|^value_//gI' | sed 's/_/./g' | sed 's/\.\./_/g')
@@ -82,7 +82,7 @@ if [ "$ACTION" != 'auth' ]; then
     fi
 fi
 
-if [ "$ACTION" == 'install' ]; then
+if [ "$ACTION" = 'install' ]; then
 	# get release name (required for install)
 	if [ -z "$RELEASE_NAME" ]; then
 		err "Please, specify Helm Release name with RELEASE_NAME environment variable"
@@ -127,9 +127,9 @@ if [ ! -z "${CHART_VERSION}" ]; then
     version="--version ${CHART_VERSION}"
 fi
 
-if [ "$ACTION" == 'auth' ]; then
+if [ "$ACTION" = 'auth' ]; then
     msg "Authentication context has been setup, exiting."
-    [[ $_ != $0 ]] && return 0 || exit 0
+    return 0 2> /dev/null || exit 0
 fi
 
 if [ ! -z "${CHART_REPO_URL}" ]; then
@@ -143,7 +143,7 @@ else #if installing from local, "unpacked" chart, then restore dependencies firs
     fi
 fi
 
-if [ "$ACTION" == 'push' ]; then
+if [ "$ACTION" = 'push' ]; then
 	msg "Packaging the chart"
 
 	if [ -z "$DRY_RUN" ]; then


### PR DESCRIPTION
Adding acceptance test suite to enable us to confidently convert this from shell to Python for better control, readability, etc.

This verifies all functionality documented here:
https://codefresh.io/docs/docs/new-helm/using-helm-in-codefresh-pipeline/

Also added `DRY_RUN` option for testing purposes, which prevents running any helm/kubectl commands.

Lastly, implemented intended functionality from #4.

cc @dustinvanbuskirk