### PR TITLE
Feature/helm3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "HELM_VERSION is set to: ${HELM_VERSION}" && mkdir /temp
 RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
     && tar -zxvf helm.tar.gz \
     && mv ./linux-amd64/helm /usr/local/bin/helm \
-    && bash -c 'if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi' \
+    && bash -c 'if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; else echo "using helm3, no need to initialize helm"; fi' \
     && helm plugin install https://github.com/hypnoglow/helm-s3.git \
     && helm plugin install https://github.com/nouney/helm-gcs.git \
     && helm plugin install https://github.com/chartmuseum/helm-push.git
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get install -y python3-venv \
     && make acceptance
 
-FROM jldeen/kube-helm:${HELM_VERSION}
+FROM codefresh/kube-helm:${HELM_VERSION}
 ARG HELM_VERSION
 COPY --from=setup /temp /root/.helm/* /root/.helm/
 COPY bin/* /opt/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ ARG HELM_VERSION
 
 FROM golang:latest as setup
 ARG HELM_VERSION
-# RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
+RUN echo "HELM_VERSION is set to: ${HELM_VERSION}" && mkdir /temp
 RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
     && tar -zxvf helm.tar.gz \
     && mv ./linux-amd64/helm /usr/local/bin/helm \
-    && helm init --client-only \
+    && bash -c 'if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi' \
     && helm plugin install https://github.com/hypnoglow/helm-s3.git \
     && helm plugin install https://github.com/nouney/helm-gcs.git \
     && helm plugin install https://github.com/chartmuseum/helm-push.git
@@ -20,9 +20,9 @@ RUN apt-get update \
     && apt-get install -y python3-venv \
     && make acceptance
 
-FROM codefresh/kube-helm:${HELM_VERSION}
+FROM jldeen/kube-helm:${HELM_VERSION}
 ARG HELM_VERSION
-COPY --from=setup /root/.helm/ /root/.helm/
+COPY --from=setup /temp /root/.helm/* /root/.helm/
 COPY bin/* /opt/bin/
 RUN chmod +x /opt/bin/*
 COPY lib/* /opt/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG HELM_VERSION
 
 FROM golang:latest as setup
 ARG HELM_VERSION
-RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
+# RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
+RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
     && tar -zxvf helm.tar.gz \
     && mv ./linux-amd64/helm /usr/local/bin/helm \
     && helm init --client-only \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,8 @@ ARG HELM_VERSION
 
 FROM arm64v8/golang:latest as setup
 ARG HELM_VERSION
-RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-arm64.tar.gz" -o helm.tar.gz \
+# RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-arm64.tar.gz" -o helm.tar.gz \
+RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
     && tar -zxvf helm.tar.gz \
     && mv ./linux-arm64/helm /usr/local/bin/helm \
     && helm init --client-only \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,12 +1,12 @@
 ARG HELM_VERSION
 
-FROM arm64v8/golang:latest as setup
+FROM arm64v8/golang:1.12-buster as setup
 ARG HELM_VERSION
-# RUN curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-arm64.tar.gz" -o helm.tar.gz \
-RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz \
+RUN echo "HELM_VERSION is set to: ${HELM_VERSION}" && mkdir /temp
+RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz" -o helm.tar.gz \
     && tar -zxvf helm.tar.gz \
     && mv ./linux-arm64/helm /usr/local/bin/helm \
-    && helm init --client-only \
+    && bash -c 'if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi' \
     && helm plugin install https://github.com/hypnoglow/helm-s3.git \
     && helm plugin install https://github.com/nouney/helm-gcs.git \
     && helm plugin install https://github.com/chartmuseum/helm-push.git
@@ -23,9 +23,11 @@ RUN apt-get update \
 
 FROM arm64v8/alpine:3.6
 
-ARG KUBE_VERSION="v1.8.1"
+ARG KUBE_VERSION="v1.14.3"
 
 ARG HELM_VERSION
+
+RUN echo "HELM_VERSION is set to: ${HELM_VERSION}"
 
 ENV FILENAME="helm-v${HELM_VERSION}-linux-arm64.tar.gz"
 
@@ -41,17 +43,17 @@ RUN apk add --update ca-certificates && update-ca-certificates \
     && pip install yq  \
     && curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && curl -L http://storage.googleapis.com/kubernetes-helm/${FILENAME} -o /tmp/${FILENAME} \
+    && curl -L https://get.helm.sh/${FILENAME} -o /tmp/${FILENAME} \
     && tar -zxvf /tmp/${FILENAME} -C /tmp \
     && mv /tmp/linux-arm64/helm /bin/helm \
     # Cleanup uncessary files
     && rm /var/cache/apk/* \
     && rm -rf /tmp/*
 
-RUN helm init --client-only
+RUN if [[ "${HELM_VERSION}" == 2* ]]; then helm init --client-only; echo "using helm3, no need to initialize helm"; fi
 
 ARG HELM_VERSION
-COPY --from=setup /root/.helm/ /root/.helm/
+COPY --from=setup /temp /root/.helm/* /root/.helm/
 COPY bin/* /opt/bin/
 RUN chmod +x /opt/bin/*
 COPY lib/* /opt/lib/

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -216,6 +216,51 @@ steps:
     build_arguments:
       - HELM_VERSION=2.12.3
     tag: 2.12.3-${{CF_SHORT_REVISION}}
+  
+  # Helm v2.14.0
+  build_2_14_0:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=2.14.0
+    tag: 2.14.0-${{CF_SHORT_REVISION}}    
+  
+  # Helm v2.14.1
+  build_2_14_1:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=2.14.1
+    tag: 2.14.1-${{CF_SHORT_REVISION}}
+  
+  # Helm v2.14.2
+  build_2_14_2:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=2.14.2
+    tag: 2.14.2-${{CF_SHORT_REVISION}}
+
+  # Helm v2.14.3
+  build_2_14_3:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=2.14.3
+    tag: 2.14.3-${{CF_SHORT_REVISION}}
+
+  # Helm v3.0.0-beta.2
+  build_3_0_0_beta_2:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=3.0.0-beta.2
+    tag: 3.0.0-beta.2-${{CF_SHORT_REVISION}}
 
   # |---------------------------------------------|
   # | Stage 2: Push all Docker Images built above |
@@ -564,6 +609,18 @@ steps:
     candidate: ${{build_2_14_3}}
     registry: dockerhub
     tag: 2.14.3
+    when:
+      branch:
+        only:
+          - master
+  
+  # Helm 3.0.0-beta.2
+  push_3_0_0_beta_2:
+    type: push
+    stage: push
+    candidate: ${{build_2_14_3}}
+    registry: dockerhub
+    tag: 3.0.0-beta.2
     when:
       branch:
         only:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -496,12 +496,84 @@ steps:
       branch:
         only:
           - master
+  
+  # Helm v2.13.0
+  push_2_13_0:
+    type: push
+    stage: push
+    candidate: ${{build_2_13_0}}
+    registry: dockerhub
+    tag: 2.13.0
+    when:
+      branch:
+        only:
+          - master
+  
+  # Helm v2.13.1
+  push_2_13_1:
+    type: push
+    stage: push
+    candidate: ${{build_2_13_1}}
+    registry: dockerhub
+    tag: 2.13.1
+    when:
+      branch:
+        only:
+          - master
 
-  # Latest tag (2.12.3)
+  # Helm v2.14.0
+  push_2_14_0:
+    type: push
+    stage: push
+    candidate: ${{build_2_14_0}}
+    registry: dockerhub
+    tag: 2.14.0
+    when:
+      branch:
+        only:
+          - master
+
+  # Helm v2.14.1
+  push_2_14_1:
+    type: push
+    stage: push
+    candidate: ${{build_2_14_1}}
+    registry: dockerhub
+    tag: 2.14.1
+    when:
+      branch:
+        only:
+          - master
+
+  # Helm v2.14.2
+  push_2_14_2:
+    type: push
+    stage: push
+    candidate: ${{build_2_14_2}}
+    registry: dockerhub
+    tag: 2.14.2
+    when:
+      branch:
+        only:
+          - master
+
+  # Helm v2.14.3
+  push_2_14_3:
+    type: push
+    stage: push
+    candidate: ${{build_2_14_3}}
+    registry: dockerhub
+    tag: 2.14.3
+    when:
+      branch:
+        only:
+          - master
+
+  # Latest tag (2.14.3)
   push_latest:
     type: push
     stage: push
-    candidate: ${{build_2_12_3}}
+    candidate: ${{build_2_14_3}}
     registry: dockerhub
     tag: latest
     when:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 title: Release a Helm chart
-image: codefresh/cfstep-helm:2.9.0 
-version: 0.1.0
+image: codefresh/cfstep-helm:2.14.3 
+version: 0.1.1
 description: 'Release a Helm chart (update or install)'
 keywords:
   - helm


### PR DESCRIPTION
* Fixes #19 
* Updated `plugin.yml` default image to `2.14.3` (latest stable version) and bumped version of `plugin.yml`
* Updated codefresh.yml with helm 3 beta.2 versions and updated the latest tag to support current latest stable version (2.14.3)
* Changed curl location for Helm to use https://get.helm.sh
* Added changes to arm64 Dockerfile
* Added check for `HELM_VERSION` 2.* vs 3.* since a home directory is no longer needed for Helm (now follows the XDG directory spec for storing files, helm init and helm home have been removed in helm3)
* echos `HELM_VERSION` in output for additional logging