### PR TITLE
add beta.4

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -271,6 +271,15 @@ steps:
       - HELM_VERSION=3.0.0-beta.3
     tag: 3.0.0-beta.3-${{CF_SHORT_REVISION}}
 
+  # Helm v3.0.0-beta.4
+  build_3_0_0_beta_4:
+    type: build
+    stage: build
+    image_name: codefresh/cfstep-helm
+    build_arguments:
+      - HELM_VERSION=3.0.0-beta.4
+    tag: 3.0.0-beta.4-${{CF_SHORT_REVISION}}
+
   # |---------------------------------------------|
   # | Stage 2: Push all Docker Images built above |
   # |---------------------------------------------|
@@ -642,6 +651,18 @@ steps:
     candidate: ${{build_3_0_0_beta_3}}
     registry: dockerhub
     tag: 3.0.0-beta.3
+    when:
+      branch:
+        only:
+          - master
+  
+  # Helm 3.0.0-beta.4
+  push_3_0_0_beta_4:
+    type: push
+    stage: push
+    candidate: ${{build_3_0_0_beta_4}}
+    registry: dockerhub
+    tag: 3.0.0-beta.4
     when:
       branch:
         only:


### PR DESCRIPTION
Add latest Helm 3 beta: Helm v3.0.0-beta.4
- Includes security fix for [CVE-2019-1000008](https://helm.sh/blog/helm-security-notice-2019/)

Per the release notes:

Several features from Helm 2 were ported over this release, including:

- the --api-versions flag from helm template, recently introduced to Helm 2
- the --wait flag now skips waiting if the object is in a "paused" state
- Ingress support for the --wait flag
- changes made recently to helm create from Helm 2
- Kubernetes objects are now submitted to Kubernetes in batches based on Kind (Deployment, Pod, Secret, etc.)
- fixed an issue where Helm now passes back the exit code from the plugin being invoked