### PR TITLE
SAAS-7894

### DIFF
--- a/bin/release_chart
+++ b/bin/release_chart
@@ -19,7 +19,7 @@ mask_cmd() {
 
 CFSTEP_HELM_ROOTDIR="${CFSTEP_HELM_ROOTDIR:-/opt}"
 
-PYTHONPATH="${CFSTEP_HELM_ROOTDIR}/lib" "${CFSTEP_HELM_ROOTDIR}/build_entrypoint_script" > /tmp/run
+PYTHONPATH="${CFSTEP_HELM_ROOTDIR}/lib" "${CFSTEP_HELM_ROOTDIR}/build_entrypoint_script"
 
 echo ""
 echo "Running the following script:"

--- a/build_entrypoint_script
+++ b/build_entrypoint_script
@@ -6,8 +6,10 @@ from lib.EntrypointScriptBuilder import EntrypointScriptBuilder
 def main():
     builder = EntrypointScriptBuilder(os.environ)
     script_source = builder.build()
-    print(script_source)
-
+    f = open('/tmp/run', 'w')
+    f.write(script_source)
+    f.flush()
+    f.close
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* Fix a bug preventing pushing to Artifactory in case if the repo URL is taken from the integration
* Better error handling and verbosity for the Artifactory repo logic
* Do not write to the /tmp/run from the bash script to avoid getting the print() output into the script contents, use Python instead to write the file
* Make the check for the Artifactory repo type to be the last one