### PR TITLE
Compare lowercase headers instead to comply with RFC7540 section 8.1.2

### DIFF
--- a/lib/EntrypointScriptBuilder.py
+++ b/lib/EntrypointScriptBuilder.py
@@ -468,21 +468,22 @@ class EntrypointScriptBuilder(object):
         print("\033[92mThe CHART_REPO_URL has been tested successfully\033[0m")
         print ("Trying to infer Helm repository type from the response headers...")
 
-        if self.isArtifactoryRepo(response):
+        if EntrypointScriptBuilder.is_artifactory_repo(response):
             helm_push_command = 'curl -u $HELMREPO_USERNAME:$HELMREPO_PASSWORD -T $PACKAGE ' + self.chart_repo_url + '$(basename $PACKAGE)'
             return helm_push_command
         else:
             raise Exception("\033[91mFailed to infer the Helm repository type\033[0m")
 
-    def isArtifactoryRepo(self, repoResponse):
+    @staticmethod
+    def is_artifactory_repo(repo_response):
         try:
-            headers = repoResponse.info()._headers
+            headers = [h.lower() for h in repo_response.info()._headers]
             for h in headers:
-                if "X-Artifactory-Id" in h or "Server" in h and "Artifactory" in h[1]:
+                if "x-artifactory-id" in h or "server" in h and "artifactory" in h[1]:
                     print("\033[94mAn Artifactory Helm repository has been recognized\033[0m")
                     return True
         except:
-            None
+            return None
         return False
 
     def _helm_3(self):


### PR DESCRIPTION
The current script won't work if HTTP/2 is used since RFC7540 section 8.1.2 says:

> Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared in a case-insensitive fashion.  However, header field names MUST be converted to lowercase prior to their encoding in HTTP/2.  A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).

What this PR accomplishes:

- Change all headers from the response to lowercase (note to maintainers: `_headers` is deprecated)
- Change the comparison headers to lowercase as well
- Change method to static as it doesn't need anything from the class instance
- Change the name of the method `isArtifactoryRepo` to `is_artifactory_repo` to meet PEP 8 recommendations as well as to match with the rest of the function naming style in the file
- Change the name of the method argument `repoResponse` to `repo_response` to meet PEP 8 recommendations as well as to match with the rest of the function naming style in the file
- Add a missing `return` when an exception occurs

