### PR TITLE
Fix helm remove duplicate plugins for versions >= 3.10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o he
     && helm plugin install https://github.com/nouney/helm-gcs.git --version=${GCS_PLUGIN_VERSION} \
     && helm plugin install https://github.com/chartmuseum/helm-push.git --version=${PUSH_PLUGIN_VERSION} \
     && helm plugin install https://github.com/databus23/helm-diff --version=${HELM_DIFF_VERSION} \
-    && bash -c 'if [[ "${HELM_VERSION}" > "3.3.1" ]]; then \
+    && bash -c 'if [[ "$HELM_VERSION" = "`echo -e "$HELM_VERSION\n3.3.1" | sort -V -r | head -n1`" ]]; then \
     rm -rf /root/.helm/helm/plugins/https-github.com-hypnoglow-helm-s3.git; \
     rm -rf /root/.helm/helm/plugins/https-github.com-nouney-helm-gcs.git; \
     rm -rf /root/.helm/helm/plugins/https-github.com-chartmuseum-helm-push.git; \


### PR DESCRIPTION
The first string comparison (if [[ "${HELM_VERSION}" > "3.3.1" ]];) may not work as expected for versions greater than or equal to 3.10.x due to the fact that string comparison in Bash is lexicographical rather than numerical. In lexicographical comparison, each character in the string is compared one by one, which may lead to unexpected results when dealing with version numbers that have more than one digit.

For instance, in lexicographical comparison:

"3.10" is considered less than "3.2" because the comparison starts with the first character and "1" comes before "2" in the ASCII character set.
Similarly, "3.10" is considered less than "3.2.1" for the same reason.
To address this limitation, the modified code uses semantic version sorting by employing the sort -V command. This ensures that version numbers are compared based on their numeric significance rather than lexicographically. The modification is designed to handle cases where the version number includes multiple digits or subversions, such as 3.10.x, and accurately determines if the version is equal to or greater than 3.3.1.
